### PR TITLE
Fixes error when setting snooze, repeat and vibration.

### DIFF
--- a/android/src/main/java/com/emekalites/react/alarm/notification/ANModule.java
+++ b/android/src/main/java/com/emekalites/react/alarm/notification/ANModule.java
@@ -62,14 +62,14 @@ public class ANModule extends ReactContextBaseJavaModule {
         Bundle data = bundle.getBundle("data");
         alarm.setData(bundle2string(data));
 
-        alarm.setInterval(bundle.getInt("repeat_interval", 1));
+        alarm.setInterval((int)bundle.getDouble("repeat_interval", 1.0));
         alarm.setLargeIcon(bundle.getString("large_icon", ""));
         alarm.setLoopSound(bundle.getBoolean("loop_sound", false));
         alarm.setMessage(bundle.getString("message", "My Notification Message"));
         alarm.setPlaySound(bundle.getBoolean("play_sound", true));
         alarm.setScheduleType(bundle.getString("schedule_type", "once"));
         alarm.setSmallIcon(bundle.getString("small_icon", "ic_launcher"));
-        alarm.setSnoozeInterval(bundle.getInt("snooze_interval", 1));
+        alarm.setSnoozeInterval((int)bundle.getDouble("snooze_interval", 1.0));
         alarm.setSoundName(bundle.getString("sound_name", null));
         alarm.setSoundNames(bundle.getString("sound_names", null));
         alarm.setTag(bundle.getString("tag", ""));
@@ -77,7 +77,7 @@ public class ANModule extends ReactContextBaseJavaModule {
         alarm.setTitle(bundle.getString("title", "My Notification Title"));
         alarm.setVibrate(bundle.getBoolean("vibrate", true));
         alarm.setHasButton(bundle.getBoolean("has_button", false));
-        alarm.setVibration(bundle.getInt("vibration", 100));
+        alarm.setVibration((int)bundle.getDouble("vibration", 100.0));
         alarm.setUseBigText(bundle.getBoolean("use_big_text", false));
 
         try {
@@ -144,14 +144,14 @@ public class ANModule extends ReactContextBaseJavaModule {
         Bundle data = bundle.getBundle("data");
         alarm.setData(bundle2string(data));
 
-        alarm.setInterval(bundle.getInt("repeat_interval", 1));
+        alarm.setInterval((int)bundle.getDouble("repeat_interval", 1));
         alarm.setLargeIcon(bundle.getString("large_icon"));
         alarm.setLoopSound(bundle.getBoolean("loop_sound", false));
         alarm.setMessage(bundle.getString("message", "My Notification Message"));
         alarm.setPlaySound(bundle.getBoolean("play_sound", true));
         alarm.setScheduleType(bundle.getString("schedule_type", "once"));
         alarm.setSmallIcon(bundle.getString("small_icon", "ic_launcher"));
-        alarm.setSnoozeInterval(bundle.getInt("snooze_interval", 1));
+        alarm.setSnoozeInterval((int)bundle.getDouble("snooze_interval", 1));
         alarm.setSoundName(bundle.getString("sound_name"));
         alarm.setSoundNames(bundle.getString("sound_names"));
         alarm.setTag(bundle.getString("tag"));
@@ -159,7 +159,7 @@ public class ANModule extends ReactContextBaseJavaModule {
         alarm.setTitle(bundle.getString("title", "My Notification Title"));
         alarm.setVibrate(bundle.getBoolean("loop_sound", true));
         alarm.setHasButton(bundle.getBoolean("has_button", false));
-        alarm.setVibration(bundle.getInt("vibration", 100));
+        alarm.setVibration((int)bundle.getDouble("vibration", 100));
         alarm.setUseBigText(bundle.getBoolean("use_big_text", false));
         
         String datetime = bundle.getString("fire_date");


### PR DESCRIPTION
When attempting to set an alarm using the `repeat_interval`, `snooze_interval` and `vibration` fields. i.e

```javascript
export const alarmNotifData = {
  alarm_id: '22',
  channel: 'wakeup',
  data: { content: 'my notification id is 22' },
  fire_date: ReactNativeAN.parseDate(new Date()),
  message: 'Stand up',
  play_sound: true,
  repeat_interval: 10,
  schedule_type: 'once',
  snooze_interval: 3,
  title: 'Alarm',
  vibrate: true,
  vibration: 100
}
```

These errors are thrown:

```
2020-07-08 23:28:13.863 29955-29992/com.kegeltrainer W/Bundle: Key repeat_interval expected Integer but value was a java.lang.Double.  The default value 1 was returned.
2020-07-08 23:28:13.863 29955-29992/com.kegeltrainer W/Bundle: Attempt to cast generated internal exception:
    java.lang.ClassCastException: java.lang.Double cannot be cast to java.lang.Integer
        at android.os.BaseBundle.getInt(BaseBundle.java:873)
        at com.emekalites.react.alarm.notification.ANModule.sendNotification(ANModule.java:147)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.facebook.react.bridge.JavaMethodWrapper.invoke(JavaMethodWrapper.java:372)
        at com.facebook.react.bridge.JavaModuleWrapper.invoke(JavaModuleWrapper.java:151)
        at com.facebook.react.bridge.queue.NativeRunnable.run(Native Method)
        at android.os.Handler.handleCallback(Handler.java:751)
        at android.os.Handler.dispatchMessage(Handler.java:95)
        at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:27)
        at android.os.Looper.loop(Looper.java:154)
        at com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run(MessageQueueThreadImpl.java:226)
        at java.lang.Thread.run(Thread.java:761)
2020-07-08 23:28:13.863 29955-29992/com.kegeltrainer W/Bundle: Key snooze_interval expected Integer but value was a java.lang.Double.  The default value 1 was returned.
2020-07-08 23:28:13.863 29955-29992/com.kegeltrainer W/Bundle: Attempt to cast generated internal exception:
    java.lang.ClassCastException: java.lang.Double cannot be cast to java.lang.Integer
        at android.os.BaseBundle.getInt(BaseBundle.java:873)
        at com.emekalites.react.alarm.notification.ANModule.sendNotification(ANModule.java:154)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.facebook.react.bridge.JavaMethodWrapper.invoke(JavaMethodWrapper.java:372)
        at com.facebook.react.bridge.JavaModuleWrapper.invoke(JavaModuleWrapper.java:151)
        at com.facebook.react.bridge.queue.NativeRunnable.run(Native Method)
        at android.os.Handler.handleCallback(Handler.java:751)
        at android.os.Handler.dispatchMessage(Handler.java:95)
        at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:27)
        at android.os.Looper.loop(Looper.java:154)
        at com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run(MessageQueueThreadImpl.java:226)
        at java.lang.Thread.run(Thread.java:761)
2020-07-08 23:28:13.863 29955-29992/com.kegeltrainer W/Bundle: Key vibration expected Integer but value was a java.lang.Double.  The default value 100 was returned.
2020-07-08 23:28:13.863 29955-29992/com.kegeltrainer W/Bundle: Attempt to cast generated internal exception:
    java.lang.ClassCastException: java.lang.Double cannot be cast to java.lang.Integer
        at android.os.BaseBundle.getInt(BaseBundle.java:873)
        at com.emekalites.react.alarm.notification.ANModule.sendNotification(ANModule.java:162)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.facebook.react.bridge.JavaMethodWrapper.invoke(JavaMethodWrapper.java:372)
        at com.facebook.react.bridge.JavaModuleWrapper.invoke(JavaModuleWrapper.java:151)
        at com.facebook.react.bridge.queue.NativeRunnable.run(Native Method)
        at android.os.Handler.handleCallback(Handler.java:751)
        at android.os.Handler.dispatchMessage(Handler.java:95)
        at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:27)
        at android.os.Looper.loop(Looper.java:154)
        at com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run(MessageQueueThreadImpl.java:226)
        at java.lang.Thread.run(Thread.java:761)
```

Tested on:
```
    "react": "16.11.0",
    "react-native": "0.62.2",
    "react-native-alarm-notification": "^1.4.6",
    Pixel 2 emulator running API 24
```

Related to #47, #65.
These changes parse the settings as `doubles` then cast them back to `ints`