### PR TITLE
cannot find symbol  alarmUtil.stopAlarmSound();

### DIFF
--- a/android/src/main/java/com/emekalites/react/alarm/notification/AlarmDismissReceiver.java
+++ b/android/src/main/java/com/emekalites/react/alarm/notification/AlarmDismissReceiver.java
@@ -10,9 +10,8 @@ import com.facebook.react.modules.core.DeviceEventManagerModule;
 public class AlarmDismissReceiver extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
+        AlarmUtil alarmUtil = new AlarmUtil((Application) context.getApplicationContext());
         try {
-            AlarmUtil alarmUtil = new AlarmUtil((Application) context.getApplicationContext());
-
             if (ANModule.getReactAppContext() != null) {
                 int notificationId = intent.getExtras().getInt(Constants.DISMISSED_NOTIFICATION_ID);
                 ANModule.getReactAppContext().getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class).emit("OnNotificationDismissed", "{\"id\": \"" + notificationId + "\"}");


### PR DESCRIPTION
during react-native run-android this error generated:  "error: cannot find symbol  alarmUtil.stopAlarmSound();"
this error is solved by placing "AlarmUtil alarmUtil = new AlarmUtil((Application) context.getApplicationContext());" outside the catch block