### PR TITLE
[fix] an error in AlarmBootReceiver

### DIFF
--- a/android/src/main/java/com/emekalites/react/alarm/notification/AlarmBootReceiver.java
+++ b/android/src/main/java/com/emekalites/react/alarm/notification/AlarmBootReceiver.java
@@ -19,7 +19,7 @@ public class AlarmBootReceiver extends BroadcastReceiver {
             ArrayList<AlarmModel> alarms = alarmDB.getAlarmList(1);
 
             try {
-                AlarmUtil alarmUtil = new AlarmUtil((Application) context);
+                AlarmUtil alarmUtil = new AlarmUtil((Application) context.getApplicationContext());
 
                 for (AlarmModel alarm : alarms) {
                     alarmUtil.setAlarm(alarm);


### PR DESCRIPTION
In `AlarmBootReceiver.java` line 22, there will be a `system error` exception when the phone reboots. 
Fixed this issue after I changed this line to be the same as in `AlarmDismissReceiver.java` and `AlarmReceiver.java`.