### PR TITLE
Using UUID to create the alarmId to resolve the scheduling alarms one after another with the same ID.

### DIFF
--- a/ios/RnAlarmNotification.m
+++ b/ios/RnAlarmNotification.m
@@ -421,7 +421,7 @@ API_AVAILABLE(ios(10.0)) {
             
             UNCalendarNotificationTrigger* trigger = [UNCalendarNotificationTrigger triggerWithDateMatchingComponents:newFireDate repeats:NO];
             
-            NSString *alarmId = [NSString stringWithFormat: @"%ld", (long) NSDate.date.timeIntervalSince1970];
+            NSString *alarmId = [[NSUUID UUID] UUIDString];
             
             NSString *soundName = [contentInfo.userInfo objectForKey:@"sound_name"];
             NSNumber *playSound = [contentInfo.userInfo objectForKey:@"sound"];
@@ -497,7 +497,7 @@ RCT_EXPORT_METHOD(scheduleAlarm: (NSDictionary *)details resolver:(RCTPromiseRes
             UNCalendarNotificationTrigger* trigger = [UNCalendarNotificationTrigger triggerWithDateMatchingComponents:fireDate repeats:NO];
             
             // alarm id
-            NSString *alarmId = [NSString stringWithFormat: @"%ld", (long) NSDate.date.timeIntervalSince1970];
+            NSString *alarmId = [[NSUUID UUID] UUIDString];
             
             NSString *volume = [details[@"volume"] stringValue];
             
@@ -571,7 +571,7 @@ RCT_EXPORT_METHOD(sendNotification: (NSDictionary *)details) {
             }
             
             // alarm id
-            NSString *alarmId = [NSString stringWithFormat: @"%ld", (long) NSDate.date.timeIntervalSince1970];
+            NSString *alarmId = [[NSUUID UUID] UUIDString];
             
             NSString *volume = [details[@"volume"] stringValue];
             


### PR DESCRIPTION
I needed to change the creation of the alarmId, because when the function `ReactNativeAN.scheduleAlarm` is used on React Native one after another. The library creates the alarms with the same ID. 

Exemple: 
```js
       const id = await ReactNativeAN.scheduleAlarm({
            title: 'My Notification 1',
            message: 'My Notification Message 1',
            channel: 'alarm_notification_channels',
            small_icon: 'ic_launcher',
            fire_date: ReactNativeAN.parseDate(new Date(Date.now() + 10000)),
            schedule_type: 'repeat',
            repeat_interval: 'hourly',
            interval_value: 2,
        });
        console.log(id);
        // Prints:  {"id": "1628714109"}

        const id0 = await ReactNativeAN.scheduleAlarm({
            title: 'My Notification 2',
            message: 'My Notification Message 2',
            channel: 'alarm_notification_channels',
            small_icon: 'ic_launcher',
            fire_date: ReactNativeAN.parseDate(new Date(Date.now() + 15000)),
            schedule_type: 'repeat',
            repeat_interval: 'hourly',
            interval_value: 2,
        });
        console.log(id0);
        // Prints:  {"id": "1628714109"}

        const id1 = await ReactNativeAN.scheduleAlarm({
            title: 'My Notification 3',
            message: 'My Notification 3',
            channel: 'alarm_notification_channels',
            small_icon: 'ic_launcher',
            fire_date: ReactNativeAN.parseDate(new Date(Date.now() + 20000)),
            schedule_type: 'repeat',
            repeat_interval: 'hourly',
            interval_value: 2,
        });
        
        console.log(id1);
       // Prints:  {"id": "1628714109"}
```