### PR TITLE
Enable android alarm duplication.

### DIFF
--- a/android/src/main/java/com/emekalites/react/alarm/notification/ANModule.java
+++ b/android/src/main/java/com/emekalites/react/alarm/notification/ANModule.java
@@ -106,21 +106,15 @@ public class ANModule extends ReactContextBaseJavaModule {
 
             alarmUtil.setAlarmFromCalendar(alarm, calendar);
 
-            // check if alarm has been set at this time
-            boolean containAlarm = alarmUtil.checkAlarm(getAlarmDB().getAlarmList(1), alarm);
-            if (!containAlarm) {
-                int id = getAlarmDB().insert(alarm);
-                alarm.setId(id);
+            int id = getAlarmDB().insert(alarm);
+            alarm.setId(id);
 
-                alarmUtil.setAlarm(alarm);
+            alarmUtil.setAlarm(alarm);
 
-                WritableMap map = Arguments.createMap();
-                map.putInt("id", id);
+            WritableMap map = Arguments.createMap();
+            map.putInt("id", id);
 
-                promise.resolve(map);
-            } else {
-                promise.reject(E_SCHEDULE_ALARM_FAILED, "duplicate alarm set at date");
-            }
+            promise.resolve(map);
         } catch (Exception e) {
             e.printStackTrace();
             promise.reject(E_SCHEDULE_ALARM_FAILED, e);

--- a/android/src/main/java/com/emekalites/react/alarm/notification/ANModule.java
+++ b/android/src/main/java/com/emekalites/react/alarm/notification/ANModule.java
@@ -16,6 +16,7 @@ import com.google.gson.Gson;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.security.SecureRandom;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -28,6 +29,7 @@ public class ANModule extends ReactContextBaseJavaModule {
     private final static String TAG = ANModule.class.getCanonicalName();
     private AlarmUtil alarmUtil;
     private static ReactApplicationContext mReactContext;
+    private SecureRandom secureRandom;
 
     private static final String E_SCHEDULE_ALARM_FAILED = "E_SCHEDULE_ALARM_FAILED";
 
@@ -35,6 +37,7 @@ public class ANModule extends ReactContextBaseJavaModule {
         super(reactContext);
         mReactContext = reactContext;
         alarmUtil = new AlarmUtil((Application) reactContext.getApplicationContext());
+        secureRandom = new SecureRandom();
     }
 
     static ReactApplicationContext getReactAppContext() {
@@ -52,56 +55,60 @@ public class ANModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void scheduleAlarm(ReadableMap details, Promise promise) throws ParseException {
-        Bundle bundle = Arguments.toBundle(details);
+        try {
+            Bundle bundle = Arguments.toBundle(details);
 
-        AlarmModel alarm = new AlarmModel();
+            AlarmModel alarm = new AlarmModel();
 
-        Random r = new Random();
-        long time = System.currentTimeMillis() / 1000 + r.nextInt(1000) ;
+            int alarmId = Math.abs(secureRandom.nextInt());
 
-        alarm.setAlarmId((int) time);
+            alarm.setAlarmId(alarmId);
 
-        alarm.setActive(1);
-        alarm.setAutoCancel(bundle.getBoolean("auto_cancel", true));
-        alarm.setChannel(bundle.getString("channel", "my_channel_id"));
-        alarm.setColor(bundle.getString("color", "red"));
+            alarm.setActive(1);
+            alarm.setAutoCancel(bundle.getBoolean("auto_cancel", true));
+            alarm.setChannel(bundle.getString("channel", "my_channel_id"));
+            alarm.setColor(bundle.getString("color", "red"));
 
-        Bundle data = bundle.getBundle("data");
-        alarm.setData(bundle2string(data));
-
-        alarm.setInterval(bundle.getString("repeat_interval", "hourly"));
-        alarm.setLargeIcon(bundle.getString("large_icon", ""));
-        alarm.setLoopSound(bundle.getBoolean("loop_sound", false));
-        alarm.setMessage(bundle.getString("message", "My Notification Message"));
-        alarm.setPlaySound(bundle.getBoolean("play_sound", true));
-        alarm.setScheduleType(bundle.getString("schedule_type", "once"));
-        alarm.setSmallIcon(bundle.getString("small_icon", "ic_launcher"));
-        alarm.setSnoozeInterval((int)bundle.getDouble("snooze_interval", 1.0));
-        alarm.setSoundName(bundle.getString("sound_name", null));
-        alarm.setSoundNames(bundle.getString("sound_names", null));
-        alarm.setTag(bundle.getString("tag", ""));
-        alarm.setTicker(bundle.getString("ticker", ""));
-        alarm.setTitle(bundle.getString("title", "My Notification Title"));
-        alarm.setVibrate(bundle.getBoolean("vibrate", true));
-        alarm.setHasButton(bundle.getBoolean("has_button", false));
-        alarm.setVibration((int)bundle.getDouble("vibration", 100.0));
-        alarm.setUseBigText(bundle.getBoolean("use_big_text", false));
-        alarm.setVolume(bundle.getDouble("volume", 0.5));
-        alarm.setIntervalValue((int)bundle.getDouble("interval_value", 1));
-        alarm.setBypassDnd(bundle.getBoolean("bypass_dnd", false));
-
-        String datetime = bundle.getString("fire_date");
-        SimpleDateFormat sdf = new SimpleDateFormat("dd-MM-yyyy HH:mm:ss", Locale.ENGLISH);
-        Calendar calendar = new GregorianCalendar();
-
-        calendar.setTime(sdf.parse(datetime));
-
-        alarmUtil.setAlarmFromCalendar(alarm, calendar);
-
-        // check if alarm has been set at this time
-        boolean containAlarm = alarmUtil.checkAlarm(getAlarmDB().getAlarmList(1), alarm);
-        if (!containAlarm) {
             try {
+                Bundle data = bundle.getBundle("data");
+                alarm.setData(bundle2string(data));
+            } catch (Exception ex) {
+                ex.printStackTrace();
+                // data is ignored because it was not informed
+            }
+
+            alarm.setInterval(bundle.getString("repeat_interval", "hourly"));
+            alarm.setLargeIcon(bundle.getString("large_icon", ""));
+            alarm.setLoopSound(bundle.getBoolean("loop_sound", false));
+            alarm.setMessage(bundle.getString("message", "My Notification Message"));
+            alarm.setPlaySound(bundle.getBoolean("play_sound", true));
+            alarm.setScheduleType(bundle.getString("schedule_type", "once"));
+            alarm.setSmallIcon(bundle.getString("small_icon", "ic_launcher"));
+            alarm.setSnoozeInterval((int)bundle.getDouble("snooze_interval", 1.0));
+            alarm.setSoundName(bundle.getString("sound_name", null));
+            alarm.setSoundNames(bundle.getString("sound_names", null));
+            alarm.setTag(bundle.getString("tag", ""));
+            alarm.setTicker(bundle.getString("ticker", ""));
+            alarm.setTitle(bundle.getString("title", "My Notification Title"));
+            alarm.setVibrate(bundle.getBoolean("vibrate", true));
+            alarm.setHasButton(bundle.getBoolean("has_button", false));
+            alarm.setVibration((int)bundle.getDouble("vibration", 100.0));
+            alarm.setUseBigText(bundle.getBoolean("use_big_text", false));
+            alarm.setVolume(bundle.getDouble("volume", 0.5));
+            alarm.setIntervalValue((int)bundle.getDouble("interval_value", 1));
+            alarm.setBypassDnd(bundle.getBoolean("bypass_dnd", false));
+
+            String datetime = bundle.getString("fire_date");
+            SimpleDateFormat sdf = new SimpleDateFormat("dd-MM-yyyy HH:mm:ss", Locale.ENGLISH);
+            Calendar calendar = new GregorianCalendar();
+
+            calendar.setTime(sdf.parse(datetime));
+
+            alarmUtil.setAlarmFromCalendar(alarm, calendar);
+
+            // check if alarm has been set at this time
+            boolean containAlarm = alarmUtil.checkAlarm(getAlarmDB().getAlarmList(1), alarm);
+            if (!containAlarm) {
                 int id = getAlarmDB().insert(alarm);
                 alarm.setId(id);
 
@@ -111,100 +118,131 @@ public class ANModule extends ReactContextBaseJavaModule {
                 map.putInt("id", id);
 
                 promise.resolve(map);
-            } catch (Exception e) {
-                e.printStackTrace();
-                promise.reject(E_SCHEDULE_ALARM_FAILED, e);
+            } else {
+                promise.reject(E_SCHEDULE_ALARM_FAILED, "duplicate alarm set at date");
             }
-        } else {
-            promise.reject(E_SCHEDULE_ALARM_FAILED, "duplicate alarm set at date");
+        } catch (Exception e) {
+            e.printStackTrace();
+            promise.reject(E_SCHEDULE_ALARM_FAILED, e);
         }
     }
 
     @ReactMethod
-    public void deleteAlarm(int alarmID) {
-        alarmUtil.deleteAlarm(alarmID);
-    }
-
-    @ReactMethod
-    public void deleteRepeatingAlarm(int alarmID) {
-        alarmUtil.deleteRepeatingAlarm(alarmID);
-    }
-
-    @ReactMethod
-    public void stopAlarmSound() {
-        alarmUtil.stopAlarmSound();
-    }
-
-    @ReactMethod
-    public void sendNotification(ReadableMap details) throws ParseException {
-        Bundle bundle = Arguments.toBundle(details);
-
-        AlarmModel alarm = new AlarmModel();
-
-        long time = System.currentTimeMillis() / 1000;
-
-        alarm.setAlarmId((int) time);
-
-        alarm.setActive(1);
-        alarm.setAutoCancel(bundle.getBoolean("auto_cancel", true));
-        alarm.setChannel(bundle.getString("channel", "my_channel_id"));
-        alarm.setColor(bundle.getString("color", "red"));
-
-        Bundle data = bundle.getBundle("data");
-        alarm.setData(bundle2string(data));
-
-        alarm.setLargeIcon(bundle.getString("large_icon"));
-        alarm.setLoopSound(bundle.getBoolean("loop_sound", false));
-        alarm.setMessage(bundle.getString("message", "My Notification Message"));
-        alarm.setPlaySound(bundle.getBoolean("play_sound", true));
-        alarm.setSmallIcon(bundle.getString("small_icon", "ic_launcher"));
-        alarm.setSnoozeInterval((int)bundle.getDouble("snooze_interval", 1));
-        alarm.setSoundName(bundle.getString("sound_name"));
-        alarm.setSoundNames(bundle.getString("sound_names"));
-        alarm.setTag(bundle.getString("tag"));
-        alarm.setTicker(bundle.getString("ticker"));
-        alarm.setTitle(bundle.getString("title", "My Notification Title"));
-        alarm.setVibrate(bundle.getBoolean("loop_sound", true));
-        alarm.setHasButton(bundle.getBoolean("has_button", false));
-        alarm.setVibration((int)bundle.getDouble("vibration", 100));
-        alarm.setUseBigText(bundle.getBoolean("use_big_text", false));
-        alarm.setVolume(bundle.getDouble("volume", 0.5));
-        alarm.setBypassDnd(bundle.getBoolean("bypass_dnd", false));
-
-        Calendar calendar = new GregorianCalendar();
-
-        alarmUtil.setAlarmFromCalendar(alarm, calendar);
-
+    public void deleteAlarm(int alarmID, Promise promise) {
+        System.out.println("delete alarm: " + alarmID);
         try {
+            alarmUtil.deleteAlarm(alarmID);
+            promise.resolve(null);
+        } catch (Exception ex) {
+            promise.reject(ex);
+        }
+    }
+
+    @ReactMethod
+    public void deleteRepeatingAlarm(int alarmID, Promise promise) {
+        System.out.println("delete repeating alarm: " + alarmID);
+        try {
+            alarmUtil.deleteRepeatingAlarm(alarmID);
+            promise.resolve(null);
+        } catch (Exception ex) {
+            promise.reject(ex);
+        }
+    }
+
+    @ReactMethod
+    public void stopAlarmSound(Promise promise) {
+        alarmUtil.stopAlarmSound();
+        promise.resolve(null);
+    }
+
+    @ReactMethod
+    public void sendNotification(ReadableMap details, Promise promise) throws ParseException {
+        try {
+            Bundle bundle = Arguments.toBundle(details);
+
+            AlarmModel alarm = new AlarmModel();
+
+            int alarmId = secureRandom.nextInt();
+
+            alarm.setAlarmId(alarmId);
+
+            alarm.setActive(1);
+            alarm.setAutoCancel(bundle.getBoolean("auto_cancel", true));
+            alarm.setChannel(bundle.getString("channel", "my_channel_id"));
+            alarm.setColor(bundle.getString("color", "red"));
+
+            Bundle data = bundle.getBundle("data");
+            alarm.setData(bundle2string(data));
+
+            alarm.setLargeIcon(bundle.getString("large_icon"));
+            alarm.setLoopSound(bundle.getBoolean("loop_sound", false));
+            alarm.setMessage(bundle.getString("message", "My Notification Message"));
+            alarm.setPlaySound(bundle.getBoolean("play_sound", true));
+            alarm.setSmallIcon(bundle.getString("small_icon", "ic_launcher"));
+            alarm.setSnoozeInterval((int)bundle.getDouble("snooze_interval", 1));
+            alarm.setSoundName(bundle.getString("sound_name"));
+            alarm.setSoundNames(bundle.getString("sound_names"));
+            alarm.setTag(bundle.getString("tag"));
+            alarm.setTicker(bundle.getString("ticker"));
+            alarm.setTitle(bundle.getString("title", "My Notification Title"));
+            alarm.setVibrate(bundle.getBoolean("loop_sound", true));
+            alarm.setHasButton(bundle.getBoolean("has_button", false));
+            alarm.setVibration((int)bundle.getDouble("vibration", 100));
+            alarm.setUseBigText(bundle.getBoolean("use_big_text", false));
+            alarm.setVolume(bundle.getDouble("volume", 0.5));
+            alarm.setBypassDnd(bundle.getBoolean("bypass_dnd", false));
+
+            Calendar calendar = new GregorianCalendar();
+
+            alarmUtil.setAlarmFromCalendar(alarm, calendar);
+
             int id = getAlarmDB().insert(alarm);
             alarm.setId(id);
 
             alarmUtil.sendNotification(alarm);
-        } catch (Exception e) {
-            e.printStackTrace();
+
+            promise.resolve(null);
+        } catch (Exception ex) {
+            promise.reject(ex);
         }
     }
 
     @ReactMethod
-    public void removeFiredNotification(int id) {
-        alarmUtil.removeFiredNotification(id);
-    }
-
-    @ReactMethod
-    public void removeAllFiredNotifications() {
-        alarmUtil.removeAllFiredNotifications();
-    }
-
-    @ReactMethod
-    public void getScheduledAlarms(Promise promise) throws JSONException {
-        ArrayList<AlarmModel> alarms = alarmUtil.getAlarms();
-        WritableArray array = Arguments.createArray();
-        Gson gson = new Gson();
-        for (AlarmModel alarm : alarms) {
-            WritableMap alarmMap = alarmUtil.convertJsonToMap(new JSONObject(gson.toJson(alarm)));
-            array.pushMap(alarmMap);
+    public void removeFiredNotification(int id, Promise promise) {
+        System.out.println("remove fired alarm: " + id);
+        try {
+            alarmUtil.removeFiredNotification(id);
+            promise.resolve(null);
+        } catch (Exception ex) {
+            promise.reject(ex);
         }
-        promise.resolve(array);
+    }
+
+    @ReactMethod
+    public void removeAllFiredNotifications(Promise promise) {
+        try {
+            alarmUtil.removeAllFiredNotifications();
+            promise.resolve(null);
+        } catch (Exception ex) {
+            promise.reject(ex);
+        }
+    }
+
+    @ReactMethod
+    public void getScheduledAlarms(Promise promise) {
+        try {
+            ArrayList<AlarmModel> alarms = alarmUtil.getAlarms();
+            WritableArray array = Arguments.createArray();
+            Gson gson = new Gson();
+            for (AlarmModel alarm : alarms) {
+                WritableMap alarmMap = alarmUtil.convertJsonToMap(new JSONObject(gson.toJson(alarm)));
+                array.pushMap(alarmMap);
+            }
+            System.out.println("count: " + array.size());
+            promise.resolve(array);
+        } catch (Exception ex) {
+            promise.reject(ex);
+        }
     }
 
     private static String bundle2string(Bundle bundle) {

--- a/android/src/main/java/com/emekalites/react/alarm/notification/AlarmUtil.java
+++ b/android/src/main/java/com/emekalites/react/alarm/notification/AlarmUtil.java
@@ -102,28 +102,6 @@ class AlarmUtil {
         });
     }
 
-    boolean checkAlarm(ArrayList<AlarmModel> alarms, AlarmModel alarm) {
-        boolean contain = false;
-        for (AlarmModel aAlarm : alarms) {
-            if (aAlarm.getHour() == alarm.getHour()
-                    && aAlarm.getMinute() == alarm.getMinute()
-                    && aAlarm.getSecond() == alarm.getSecond()
-                    && aAlarm.getDay() == alarm.getDay()
-                    && aAlarm.getMonth() == alarm.getMonth()
-                    && aAlarm.getYear() == alarm.getYear()
-                    && aAlarm.getActive() == 1) {
-                contain = true;
-                break;
-            }
-        }
-
-        if (contain) {
-            Toast.makeText(mContext, "You have already set this Alarm", Toast.LENGTH_SHORT).show();
-        }
-
-        return contain;
-    }
-
     void setBootReceiver() {
         ArrayList<AlarmModel> alarms = getAlarmDB().getAlarmList(1);
         if (alarms.size() > 0) {

--- a/android/src/main/java/com/emekalites/react/alarm/notification/AlarmUtil.java
+++ b/android/src/main/java/com/emekalites/react/alarm/notification/AlarmUtil.java
@@ -105,7 +105,13 @@ class AlarmUtil {
     boolean checkAlarm(ArrayList<AlarmModel> alarms, AlarmModel alarm) {
         boolean contain = false;
         for (AlarmModel aAlarm : alarms) {
-            if (aAlarm.getHour() == alarm.getHour() && aAlarm.getMinute() == alarm.getMinute() && aAlarm.getDay() == alarm.getDay() && aAlarm.getMonth() == alarm.getMonth() && aAlarm.getYear() == alarm.getYear() && aAlarm.getActive() == 1) {
+            if (aAlarm.getHour() == alarm.getHour()
+                    && aAlarm.getMinute() == alarm.getMinute()
+                    && aAlarm.getSecond() == alarm.getSecond()
+                    && aAlarm.getDay() == alarm.getDay()
+                    && aAlarm.getMonth() == alarm.getMonth()
+                    && aAlarm.getYear() == alarm.getYear()
+                    && aAlarm.getActive() == 1) {
                 contain = true;
                 break;
             }

--- a/ios/RnAlarmNotification.m
+++ b/ios/RnAlarmNotification.m
@@ -421,7 +421,7 @@ API_AVAILABLE(ios(10.0)) {
             
             UNCalendarNotificationTrigger* trigger = [UNCalendarNotificationTrigger triggerWithDateMatchingComponents:newFireDate repeats:NO];
             
-            NSString *alarmId = [NSString stringWithFormat: @"%ld", (long) NSDate.date.timeIntervalSince1970];
+            NSString *alarmId = [[NSUUID UUID] UUIDString];
             
             NSString *soundName = [contentInfo.userInfo objectForKey:@"sound_name"];
             NSNumber *playSound = [contentInfo.userInfo objectForKey:@"sound"];
@@ -497,7 +497,7 @@ RCT_EXPORT_METHOD(scheduleAlarm: (NSDictionary *)details resolver:(RCTPromiseRes
             UNCalendarNotificationTrigger* trigger = [UNCalendarNotificationTrigger triggerWithDateMatchingComponents:fireDate repeats:NO];
             
             // alarm id
-            NSString *alarmId = [NSString stringWithFormat: @"%ld", (long) NSDate.date.timeIntervalSince1970];
+            NSString *alarmId = [[NSUUID UUID] UUIDString];
             
             NSString *volume = [details[@"volume"] stringValue];
             
@@ -557,7 +557,7 @@ RCT_EXPORT_METHOD(scheduleAlarm: (NSDictionary *)details resolver:(RCTPromiseRes
     }
 }
 
-RCT_EXPORT_METHOD(sendNotification: (NSDictionary *)details) {
+RCT_EXPORT_METHOD(sendNotification: (NSDictionary *)details resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
     @try {
         NSLog(@"send notification now");
         if (@available(iOS 10.0, *)) {
@@ -571,7 +571,7 @@ RCT_EXPORT_METHOD(sendNotification: (NSDictionary *)details) {
             }
             
             // alarm id
-            NSString *alarmId = [NSString stringWithFormat: @"%ld", (long) NSDate.date.timeIntervalSince1970];
+            NSString *alarmId = [[NSUUID UUID] UUIDString];
             
             NSString *volume = [details[@"volume"] stringValue];
             
@@ -604,58 +604,85 @@ RCT_EXPORT_METHOD(sendNotification: (NSDictionary *)details) {
         } else {
             // Fallback on earlier versions
         }
+        resolve(nil);
     } @catch(NSException *exception){
         NSLog(@"error: %@", exception.reason);
+        reject(exception.name, exception.reason, nil);
     }
 }
 
-RCT_EXPORT_METHOD(deleteAlarm: (NSInteger *)id){
-    NSLog(@"delete alarm: %li", (long) id);
-    if (@available(iOS 10.0, *)) {
-        UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
-        NSArray *array = [NSArray arrayWithObjects:[NSString stringWithFormat:@"%li", (long)id], nil];
-        [center removePendingNotificationRequestsWithIdentifiers:array];
-    } else {
-        // Fallback on earlier versions
+RCT_EXPORT_METHOD(deleteAlarm: (NSString *)alarmId resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject){
+    NSLog(@"delete alarm: %@", alarmId);
+    @try {
+        if (@available(iOS 10.0, *)) {
+            UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+            NSArray *array = [NSArray arrayWithObjects:alarmId, nil];
+            [center removePendingNotificationRequestsWithIdentifiers:array];
+        } else {
+            // Fallback on earlier versions
+        }
+        resolve(nil);
+    } @catch(NSException *exception){
+        NSLog(@"error: %@", exception.reason);
+        reject(exception.name, exception.reason, nil);
     }
 }
 
-RCT_EXPORT_METHOD(deleteRepeatingAlarm: (NSInteger *)id){
-    NSLog(@"delete alarm: %li", (long) id);
-    if (@available(iOS 10.0, *)) {
-        UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
-        NSArray *array = [NSArray arrayWithObjects:[NSString stringWithFormat:@"%li", (long)id], nil];
-        [center removePendingNotificationRequestsWithIdentifiers:array];
-    } else {
-        // Fallback on earlier versions
+RCT_EXPORT_METHOD(deleteRepeatingAlarm: (NSString *)alarmId resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject){
+    NSLog(@"delete repeating alarm: %@", alarmId);
+    @try {
+        if (@available(iOS 10.0, *)) {
+            UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+            NSArray *array = [NSArray arrayWithObjects:alarmId, nil];
+            [center removePendingNotificationRequestsWithIdentifiers:array];
+        } else {
+            // Fallback on earlier versions
+        }
+        resolve(nil);
+    } @catch(NSException *exception){
+        NSLog(@"error: %@", exception.reason);
+        reject(exception.name, exception.reason, nil);
     }
 }
 
-RCT_EXPORT_METHOD(stopAlarmSound){
+RCT_EXPORT_METHOD(stopAlarmSound:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject){
     NSLog(@"stop alarm sound");
     [RnAlarmNotification stopSound];
+    resolve(nil);
 }
 
-RCT_EXPORT_METHOD(removeFiredNotification: (NSInteger)id){
-    NSLog(@"remove fired notification: %li", (long) id);
-    if (@available(iOS 10.0, *)) {
-        UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
-        NSArray *array = [NSArray arrayWithObjects:[NSString stringWithFormat:@"%li", (long)id], nil];
-        [center removeDeliveredNotificationsWithIdentifiers:array];
-    } else {
-        // Fallback on earlier versions
+RCT_EXPORT_METHOD(removeFiredNotification: (NSString *)alarmId resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject){
+    NSLog(@"remove fired notification: %@", alarmId);
+    @try {
+        if (@available(iOS 10.0, *)) {
+            UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+            NSArray *array = [NSArray arrayWithObjects:alarmId, nil];
+            [center removeDeliveredNotificationsWithIdentifiers:array];
+        } else {
+            // Fallback on earlier versions
+        }
+        resolve(nil);
+    } @catch(NSException *exception){
+        NSLog(@"error: %@", exception.reason);
+        reject(exception.name, exception.reason, nil);
     }
 }
 
-RCT_EXPORT_METHOD(removeAllFiredNotifications){
+RCT_EXPORT_METHOD(removeAllFiredNotifications:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject){
     NSLog(@"remove all notifications");
-    if (@available(iOS 10.0, *)) {
-        if ([UNUserNotificationCenter class]) {
-            UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
-            [center removeAllDeliveredNotifications];
+    @try {
+        if (@available(iOS 10.0, *)) {
+            if ([UNUserNotificationCenter class]) {
+                UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+                [center removeAllDeliveredNotifications];
+            }
+        } else {
+            // Fallback on earlier versions
         }
-    } else {
-        // Fallback on earlier versions
+        resolve(nil);
+    } @catch(NSException *exception){
+        NSLog(@"error: %@", exception.reason);
+        reject(exception.name, exception.reason, nil);
     }
 }
 
@@ -684,7 +711,7 @@ RCT_EXPORT_METHOD(getScheduledAlarms: (RCTPromiseResolveBlock)resolve rejecter:(
         UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
         
         [center getPendingNotificationRequestsWithCompletionHandler:^(NSArray<UNNotificationRequest *> * _Nonnull requests) {
-            NSLog(@"count%lu",(unsigned long)requests.count);
+            NSLog(@"count %lu",(unsigned long)requests.count);
             
             NSMutableArray<NSDictionary *> *formattedNotifications = [NSMutableArray new];
             


### PR DESCRIPTION
Removed the validation:

```js
        boolean containAlarm = alarmUtil.checkAlarm(getAlarmDB().getAlarmList(1), alarm);
        if (!containAlarm) {
            ...
        } else {
              promise.reject(E_SCHEDULE_ALARM_FAILED, "duplicate alarm set at date");
        }
```

And the function:
```js
 boolean checkAlarm(ArrayList<AlarmModel> alarms, AlarmModel alarm) {
        boolean contain = false;
        for (AlarmModel aAlarm : alarms) {
            if (aAlarm.getHour() == alarm.getHour()
                    && aAlarm.getMinute() == alarm.getMinute()
                    && aAlarm.getSecond() == alarm.getSecond()
                    && aAlarm.getDay() == alarm.getDay()
                    && aAlarm.getMonth() == alarm.getMonth()
                    && aAlarm.getYear() == alarm.getYear()
                    && aAlarm.getActive() == 1) {
                contain = true;
                break;
            }
        }

        if (contain) {
            Toast.makeText(mContext, "You have already set this Alarm", Toast.LENGTH_SHORT).show();
        }

        return contain;
    }
```

To enable the creation of alarms with the same fire date on Android.