### PR TITLE
add getInitialNotification to handle when opened from a quit state in android

### DIFF
--- a/android/src/main/java/com/emekalites/react/alarm/notification/ANModule.java
+++ b/android/src/main/java/com/emekalites/react/alarm/notification/ANModule.java
@@ -1,6 +1,8 @@
 package com.emekalites.react.alarm.notification;
 
 import android.app.Application;
+import android.app.Activity;
+import android.content.Intent;
 import android.os.Bundle;
 
 import com.facebook.react.bridge.Arguments;
@@ -48,6 +50,20 @@ public class ANModule extends ReactContextBaseJavaModule {
 
     private AlarmDatabase getAlarmDB() {
         return new AlarmDatabase(mReactContext);
+    }
+
+    @ReactMethod
+    public void getInitialNotification(Promise promise) {
+        Activity activity = getCurrentActivity();
+        if (activity != null) {
+            Intent intent = activity.getIntent();
+            if (intent != null && intent.getExtras() != null) {
+                Bundle bundle = intent.getExtras();
+                JSONObject json = alarmUtil.convertBundleToJson(bundle);
+                promise.resolve(json.toString());
+            }
+        }
+        promise.resolve(null);
     }
 
     @ReactMethod

--- a/android/src/main/java/com/emekalites/react/alarm/notification/AlarmUtil.java
+++ b/android/src/main/java/com/emekalites/react/alarm/notification/AlarmUtil.java
@@ -552,4 +552,23 @@ class AlarmUtil {
         }
         return map;
     }
+
+    JSONObject convertBundleToJson(Bundle bundle) {
+        JSONObject json = new JSONObject();
+        try {
+            for (String key : bundle.keySet()) {
+                Object value = bundle.get(key);
+
+                if (value instanceof Bundle) {
+                    json.put(key, this.convertBundleToJson((Bundle) value));
+                    continue;
+                }
+
+                json.put(key, JSONObject.wrap(value));
+            }
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+        return json;
+    }
 }

--- a/example/App.js
+++ b/example/App.js
@@ -154,6 +154,14 @@ class App extends Component {
 			},
 		);
 
+		if (Platform.OS === 'android') {
+			ReactNativeAN.getInitialNotification().then((data) => {
+				console.log(data);
+				const obj = JSON.parse(data);
+				console.log(`app opened by notification: ${obj.id}`);
+			});
+		}
+
 		// check ios permissions
 		if (Platform.OS === 'ios') {
 			this.showPermissions();


### PR DESCRIPTION
This fixes https://github.com/emekalites/react-native-alarm-notification/issues/103

In Android, `OnNotificationOpened` event is not triggered when the app is opened from a quit state.
So, I took the same approach with https://rnfirebase.io/messaging/notifications#handling-interaction, introducing a new method `getInitialNotification()` that you can use for that case.