### PR TITLE
Stop ringing when dismissed from a quit state in android

### DIFF
--- a/android/src/main/java/com/emekalites/react/alarm/notification/AlarmDismissReceiver.java
+++ b/android/src/main/java/com/emekalites/react/alarm/notification/AlarmDismissReceiver.java
@@ -12,14 +12,14 @@ public class AlarmDismissReceiver extends BroadcastReceiver {
     public void onReceive(Context context, Intent intent) {
         AlarmUtil alarmUtil = new AlarmUtil((Application) context.getApplicationContext());
         try {
+            int notificationId = intent.getExtras().getInt(Constants.DISMISSED_NOTIFICATION_ID);
+
             if (ANModule.getReactAppContext() != null) {
-                int notificationId = intent.getExtras().getInt(Constants.DISMISSED_NOTIFICATION_ID);
                 ANModule.getReactAppContext().getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class).emit("OnNotificationDismissed", "{\"id\": \"" + notificationId + "\"}");
-
-                alarmUtil.removeFiredNotification(notificationId);
-
-                alarmUtil.doCancelAlarm(notificationId);
             }
+
+            alarmUtil.removeFiredNotification(notificationId);
+            alarmUtil.doCancelAlarm(notificationId);
         } catch (Exception e) {
             alarmUtil.stopAlarmSound();
             System.err.println("Exception when handling notification dismiss. " + e);


### PR DESCRIPTION
This fixes https://github.com/emekalites/react-native-alarm-notification/issues/82

In Android, you can dismiss the alarm directly from the notification panel, and in that case, you can't get ReactAppContext if the app is in a quit state.