### PR TITLE
use setExactAndAllowWhileIdle for exact scheduling

### DIFF
--- a/android/src/main/java/com/emekalites/react/alarm/notification/AlarmUtil.java
+++ b/android/src/main/java/com/emekalites/react/alarm/notification/AlarmUtil.java
@@ -145,7 +145,7 @@ class AlarmUtil {
 
         if (scheduleType.equals("once")) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                alarmManager.setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, calendar.getTimeInMillis(), alarmIntent);
+                alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, calendar.getTimeInMillis(), alarmIntent);
             } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
                 alarmManager.setExact(AlarmManager.RTC_WAKEUP, calendar.getTimeInMillis(), alarmIntent);
             } else {


### PR DESCRIPTION
This fixes https://github.com/emekalites/react-native-alarm-notification/issues/145

By using **setExactAndAllowWhileIdle()** instead of **setAndAllowWhileIdle()**, you can force the alarm to ring at the exact time.