### PR TITLE
fix getScheduledAlarms() to return data set in scheduleAlarm()

### DIFF
--- a/ios/RnAlarmNotification.m
+++ b/ios/RnAlarmNotification.m
@@ -674,6 +674,7 @@ static NSDictionary *RCTFormatUNNotificationRequest(UNNotificationRequest *reque
     formattedNotification[@"hour"] = [NSString stringWithFormat:@"%li", (long)fireDate.hour];
     formattedNotification[@"minute"] =[NSString stringWithFormat:@"%li", (long)fireDate.minute];
     formattedNotification[@"second"] = [NSString stringWithFormat:@"%li", (long)fireDate.second];
+    formattedNotification[@"data"] = RCTNullIfNil([content.userInfo objectForKey:@"data"]);
 
     return formattedNotification;
 }


### PR DESCRIPTION
This fixes https://github.com/emekalites/react-native-alarm-notification/issues/147