### PR TITLE
support complex JSON object from sendNotification in android

### DIFF
--- a/android/src/main/java/com/emekalites/react/alarm/notification/ANModule.java
+++ b/android/src/main/java/com/emekalites/react/alarm/notification/ANModule.java
@@ -67,7 +67,7 @@ public class ANModule extends ReactContextBaseJavaModule {
         alarm.setColor(bundle.getString("color", "red"));
 
         Bundle data = bundle.getBundle("data");
-        alarm.setData(bundle2string(data));
+        alarm.setData(bundleToString(data));
 
         alarm.setInterval(bundle.getString("repeat_interval", "hourly"));
         alarm.setLargeIcon(bundle.getString("large_icon", ""));
@@ -151,7 +151,7 @@ public class ANModule extends ReactContextBaseJavaModule {
         alarm.setColor(bundle.getString("color", "red"));
 
         Bundle data = bundle.getBundle("data");
-        alarm.setData(bundle2string(data));
+        alarm.setData(bundleToString(data));
 
         alarm.setLargeIcon(bundle.getString("large_icon"));
         alarm.setLoopSound(bundle.getBoolean("loop_sound", false));
@@ -207,14 +207,15 @@ public class ANModule extends ReactContextBaseJavaModule {
         promise.resolve(array);
     }
 
-    private static String bundle2string(Bundle bundle) {
-        if (bundle == null) {
-            return null;
-        }
-        StringBuilder string = new StringBuilder();
+    private static String bundleToString(Bundle bundle) {
+        JSONObject json = new JSONObject();
         for (String key : bundle.keySet()) {
-            string.append(key).append("==>").append(bundle.get(key)).append(";;");
+            try {
+                json.put(key, JSONObject.wrap(bundle.get(key)));
+            } catch (JSONException e) {
+                e.printStackTrace();
+            }
         }
-        return string.toString();
+        return json.toString();
     }
 }

--- a/android/src/main/java/com/emekalites/react/alarm/notification/AlarmUtil.java
+++ b/android/src/main/java/com/emekalites/react/alarm/notification/AlarmUtil.java
@@ -385,15 +385,9 @@ class AlarmUtil {
             intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
 
             Bundle bundle = new Bundle();
-            if (alarm.getData() != null && !alarm.getData().equals("")) {
-                String[] datum = alarm.getData().split(";;");
-                for (String item : datum) {
-                    String[] data = item.split("==>");
-                    bundle.putString(data[0], data[1]);
-                }
-
-                intent.putExtras(bundle);
-            }
+            bundle.putInt("id", alarm.getId());
+            bundle.putBundle("data", this.convertJsonToBundle(new JSONObject(alarm.getData())));
+            intent.putExtras(bundle);
 
             PendingIntent pendingIntent = PendingIntent.getActivity(mContext, notificationID, intent, PendingIntent.FLAG_UPDATE_CURRENT);
 
@@ -551,5 +545,44 @@ class AlarmUtil {
             }
         }
         return map;
+    }
+
+    Bundle convertJsonToBundle(JSONObject json) {
+        Bundle bundle = new Bundle();
+        try {
+            Iterator<String> iterator = json.keys();
+            while (iterator.hasNext()) {
+                String key = (String) iterator.next();
+                Object value = json.get(key);
+                switch (value.getClass().getSimpleName()) {
+                    case "String":
+                        bundle.putString(key, (String) value);
+                        break;
+                    case "Integer":
+                        bundle.putInt(key, (Integer) value);
+                        break;
+                    case "Long":
+                        bundle.putLong(key, (Long) value);
+                        break;
+                    case "Boolean":
+                        bundle.putBoolean(key, (Boolean) value);
+                        break;
+                    case "JSONObject":
+                        bundle.putBundle(key, convertJsonToBundle((JSONObject) value));
+                        break;
+                    case "Float":
+                        bundle.putFloat(key, (Float) value);
+                        break;
+                    case "Double":
+                        bundle.putDouble(key, (Double) value);
+                        break;
+                    default:
+                        bundle.putString(key, value.getClass().getSimpleName());
+                }
+            }
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+        return bundle;
     }
 }


### PR DESCRIPTION
Currently, the structure of JSON data is pretty limited when you send it from `sendNotification()` in android.
I've revised it to support free and more complex JSON data structure, and even you can use it as an object type instead of string type from Javascript side, like in iOS.