### PR TITLE
Fix alarm scheduling on iOS by setting the alarm ID based on alarm fire date instead of current timestamp

### DIFF
--- a/ios/RnAlarmNotification.m
+++ b/ios/RnAlarmNotification.m
@@ -497,7 +497,8 @@ RCT_EXPORT_METHOD(scheduleAlarm: (NSDictionary *)details resolver:(RCTPromiseRes
             UNCalendarNotificationTrigger* trigger = [UNCalendarNotificationTrigger triggerWithDateMatchingComponents:fireDate repeats:NO];
             
             // alarm id
-            NSString *alarmId = [NSString stringWithFormat: @"%ld", (long) NSDate.date.timeIntervalSince1970];
+            NSCalendar *gregorianCalendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
+            NSString *alarmId = [NSString stringWithFormat: @"%ld", (long) [[gregorianCalendar dateFromComponents:fireDate] timeIntervalSince1970]];
             
             NSString *volume = [details[@"volume"] stringValue];
             


### PR DESCRIPTION
This should fix issue #96 for the schedule of multiple alarms. The problem is that by using `NSDate.date.timeIntervalSince1970`, subsequent alarm schedules get the same ID and thus overwrite the previous schedule on iOS as per `[UNNotificationRequest requestWithIdentifier: content: trigger:] documentation`.

The proposed fix here will use the fire date to generate the alarm ID, it will work as long as no alarm date/times clashes.